### PR TITLE
fix: resolve all compiler warnings

### DIFF
--- a/list_interpreter.mbt
+++ b/list_interpreter.mbt
@@ -14,7 +14,7 @@ pub struct Environment {
 
 ///| Implement Show for Environment to satisfy Value's Show derivation
 ///
-impl Show for Environment with output(_, logger) {
+pub impl Show for Environment with output(_, logger) {
   logger.write_string("{...}")
 }
 
@@ -44,7 +44,7 @@ priv suberror EvalError {
 
 ///| Implement Show for Value
 ///
-impl Show for Value with output(self, logger) {
+pub impl Show for Value with output(self, logger) {
   match self {
     Value::Number(n) => logger.write_string(n.to_string())
     Value::Boolean(b) => logger.write_string(b.to_string())
@@ -229,7 +229,7 @@ fn string_to_int(s : String) -> Int raise Failure {
     // Continue processing from index 1, skipping the '-' sign
     let mut i = 1
     while i < s.length() {
-      let char = s.charcode_at(i)
+      let char = s[i]
       if char is ('0'..='9') {
         let digit = char - '0'
         result = result * 10 + digit
@@ -242,7 +242,7 @@ fn string_to_int(s : String) -> Int raise Failure {
     // Process a positive number
     let mut i = 0
     while i < s.length() {
-      let char = s.charcode_at(i)
+      let char = s[i]
       if char is ('0'..='9') {
         let digit = char - '0'
         result = result * 10 + digit

--- a/list_interpreter_test.mbt
+++ b/list_interpreter_test.mbt
@@ -49,47 +49,47 @@ test "evaluate conditions" {
   // Test if expressions
   inspect(
     evaluate_string("(if (> 5 2) 1 0)"),
-    content=
+    content=(
       #|Atom("1")
-    ,
+    ),
   )
   inspect(
     evaluate_string("(if (< 5 2) 1 0)"),
-    content=
+    content=(
       #|Atom("0")
-    ,
+    ),
   )
   inspect(
     evaluate_string("(if (= 5 5) 1 0)"),
-    content=
+    content=(
       #|Atom("1")
-    ,
+    ),
   )
 
   // Test comparison and logical operators
   inspect(
     evaluate_string("(> 5 2)"),
-    content=
+    content=(
       #|Atom("true")
-    ,
+    ),
   ) // true represented as 1
   inspect(
     evaluate_string("(< 5 2)"),
-    content=
+    content=(
       #|Atom("false")
-    ,
+    ),
   ) // false represented as 0
   inspect(
     evaluate_string("(= 5 5)"),
-    content=
+    content=(
       #|Atom("true")
-    ,
+    ),
   )
   inspect(
     evaluate_string("(= 5 2)"),
-    content=
+    content=(
       #|Atom("false")
-    ,
+    ),
   )
 }
 

--- a/sexp.mbt
+++ b/sexp.mbt
@@ -23,7 +23,7 @@ pub fn parse_sexp(input : String) -> Sexp raise ParseError {
 
 ///|
 fn parse_tokens(
-  tokens : @array.View[@string.View]
+  tokens : @array.View[@string.View],
 ) -> (Sexp, @array.View[@string.View]) raise ParseError {
   match tokens {
     [] => raise UnexpectedEOF

--- a/sexp.mbt
+++ b/sexp.mbt
@@ -2,14 +2,14 @@
 pub(all) enum Sexp {
   Atom(String)
   List(Array[Sexp])
-} derive(Show, Eq, ToJson)
+} derive(Show, Eq, ToJson(style="legacy"))
 
 ///|
 suberror ParseError {
   UnmatchedParens(String)
   UnexpectedParens(String)
   UnexpectedEOF
-} derive(Show, ToJson)
+} derive(Show, ToJson(style="legacy"))
 
 ///|
 pub fn parse_sexp(input : String) -> Sexp raise ParseError {

--- a/sexp.mbti
+++ b/sexp.mbti
@@ -1,4 +1,9 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "bobzhang/sexp"
+
+import(
+  "moonbitlang/core/string"
+)
 
 // Values
 fn create_standard_env() -> Environment
@@ -7,16 +12,17 @@ fn evaluate(Sexp) -> Sexp raise
 
 fn parse_sexp(String) -> Sexp raise ParseError
 
-fn tokenize(@moonbitlang/core/string.StringView) -> Array[@moonbitlang/core/string.StringView]
+fn tokenize(@string.StringView) -> Array[@string.StringView]
+
+// Errors
+type ParseError
+impl Show for ParseError
+impl ToJson for ParseError
 
 // Types and methods
 pub struct Environment {
   bindings : Map[String, Value]
 }
-
-type ParseError
-impl Show for ParseError
-impl ToJson for ParseError
 
 pub(all) enum Sexp {
   Atom(String)

--- a/sexp.mbti
+++ b/sexp.mbti
@@ -23,6 +23,7 @@ impl ToJson for ParseError
 pub struct Environment {
   bindings : Map[String, Value]
 }
+impl Show for Environment
 
 pub(all) enum Sexp {
   Atom(String)
@@ -39,6 +40,7 @@ pub(all) enum Value {
   Function(Array[String], Sexp, Environment)
   BuiltinFunction(String)
 }
+impl Show for Value
 
 // Type aliases
 

--- a/sexp_test.mbt
+++ b/sexp_test.mbt
@@ -76,9 +76,9 @@ test "parse error" {
   let input = "(hello (world"
   inspect(
     try? parse_sexp(input),
-    content=
+    content=(
       #|Err(UnmatchedParens("missing closing parenthesis"))
-    ,
+    ),
   )
 }
 


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

- Make Show trait implementations for Environment and Value public to fix unused warnings
- Replace deprecated charcode_at calls with array access syntax (s[i])
- Add style="legacy" to ToJson derives to maintain backward compatibility

All MoonBit compiler warnings have been resolved while maintaining existing functionality.