### PR TITLE
chore: migrate lisp_interpreter off nightly deprecations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 target/
 .mooncakes/
 .DS_Store
-logs.json
+logs.json_build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 target/
 .mooncakes/
 .DS_Store
-logs.json_build/
+logs.json
+_build/
+

--- a/lisp_interpreter.mbt
+++ b/lisp_interpreter.mbt
@@ -5,7 +5,7 @@ pub(all) enum Value {
   Symbol(String)
   Function(Array[String], Sexp, Env)
   BuiltinFunction(String)
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub impl ToJson for Value with to_json(self) {
@@ -20,8 +20,8 @@ pub impl ToJson for Value with to_json(self) {
 
 ///|
 pub struct Env {
-  mut inner : @immut/sorted_map.SortedMap[String, Value]
-} derive(Show)
+  mut inner : @sorted_map.SortedMap[String, Value]
+} derive(Debug)
 
 // ///|
 // fn Environment::new() -> Environment {
@@ -51,11 +51,11 @@ priv suberror EvalError {
   NotAFunction(String)
   WrongArgumentCount(String)
   TypeError(String)
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub fn Env::builtin() -> Self {
-  let env = { inner: @immut/sorted_map.SortedMap::new() }
+  let env = { inner: @sorted_map.SortedMap::new() }
   env.set(".", BuiltinFunction("dummy"))
   env.set("+", BuiltinFunction("+"))
   env.set("-", BuiltinFunction("-"))
@@ -91,7 +91,7 @@ fn Sexp::eval(self : Sexp, env : Env) -> Value raise EvalError {
       // Try parsing as an integer
       if token is ['0'..='9', ..] || token is ['-', '0'..='9', ..] {
         try {
-          let num = @strconv.parse_int(token)
+          let num = @string.parse_int(token)
           return Value::Number(num)
         } catch {
           _ => () // Not a number, continue
@@ -445,4 +445,19 @@ fn is_truthy(val : Value) -> Bool {
     Symbol("nil") => false
     _ => true
   }
+}
+
+///|
+pub impl Show for Value with output(self, logger) {
+  logger.write_string(@debug.render(self.to_repr(), max_depth=2147483647))
+}
+
+///|
+pub impl Show for Env with output(self, logger) {
+  logger.write_string(@debug.render(self.to_repr(), max_depth=2147483647))
+}
+
+///|
+impl Show for EvalError with output(self, logger) {
+  logger.write_string(@debug.render(self.to_repr(), max_depth=2147483647))
 }

--- a/lisp_interpreter_test.mbt
+++ b/lisp_interpreter_test.mbt
@@ -45,10 +45,10 @@ fn eval_string(
     let result = @lisp_interpreter.evaluate(sexp)
     result.to_json()
   } catch {
-    Failure(err) => { "Err": err.split("FAILED:")[1:].to_string() }
+    @builtin.Failure(err) => { "Err": err.split("FAILED:")[1:].to_string() }
     err => { "Err": err.to_string() }
   }
-  @json.inspect(json, content?, loc~, args_loc~)
+  json_inspect(json, content?, loc~, args_loc~)
 }
 
 ///|

--- a/moon.pkg
+++ b/moon.pkg
@@ -1,0 +1,8 @@
+import {
+  "moonbitlang/core/array",
+  "moonbitlang/core/builtin",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/immut/sorted_map",
+  "moonbitlang/core/json",
+  "moonbitlang/core/string",
+}

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -1,40 +1,38 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "bobzhang/lisp_interpreter"
 
-import(
-  "moonbitlang/core/immut/sorted_map"
-)
+import {
+  "moonbitlang/core/debug",
+  "moonbitlang/core/immut/sorted_map",
+}
 
 // Values
-fn eval(String) -> Value raise
+pub fn eval(String) -> Value raise
 
-fn evaluate(Sexp) -> Value raise
+pub fn evaluate(Sexp) -> Value raise
 
-fn parse_sexp(String) -> Sexp raise
+pub fn parse_sexp(String) -> Sexp raise
 
 // Errors
 pub suberror ParseError {
   UnmatchedParens(String)
   UnexpectedParens(String)
   UnexpectedEOF
-}
-impl Show for ParseError
-impl ToJson for ParseError
+} derive(ToJson, @debug.Debug)
+pub impl Show for ParseError
 
 // Types and methods
 pub struct Env {
   mut inner : @sorted_map.SortedMap[String, Value]
-}
-fn Env::builtin() -> Self
-impl Show for Env
+} derive(@debug.Debug)
+pub fn Env::builtin() -> Self
+pub impl Show for Env
 
 pub(all) enum Sexp {
   Atom(String)
   List(Array[Sexp])
-}
-impl Eq for Sexp
-impl Show for Sexp
-impl ToJson for Sexp
+} derive(Eq, ToJson, @debug.Debug)
+pub impl Show for Sexp
 
 pub(all) enum Value {
   Number(Int)
@@ -42,9 +40,9 @@ pub(all) enum Value {
   Symbol(String)
   Function(Array[String], Sexp, Env)
   BuiltinFunction(String)
-}
-impl Show for Value
-impl ToJson for Value
+} derive(@debug.Debug)
+pub impl Show for Value
+pub impl ToJson for Value
 
 // Type aliases
 

--- a/sexp.mbt
+++ b/sexp.mbt
@@ -2,7 +2,7 @@
 pub(all) enum Sexp {
   Atom(String)
   List(Array[Sexp])
-} derive(Show, Eq, ToJson)
+} derive(Debug, Eq, ToJson)
 
 ///|
 /// TODO(upstream):
@@ -17,7 +17,7 @@ pub suberror ParseError {
   UnmatchedParens(String)
   UnexpectedParens(String)
   UnexpectedEOF
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv enum Token {
@@ -47,19 +47,21 @@ pub fn parse_sexp(input : String) -> Sexp raise {
 
 ///|
 fn parse_tokens(
-  tokens : @array.View[Token],
-) -> (Sexp, @array.View[Token]) raise ParseError {
+  tokens : ArrayView[Token],
+) -> (Sexp, ArrayView[Token]) raise ParseError {
   match tokens {
     [] => raise UnexpectedEOF
     [Lparen, .. rest] => {
       let subexps = []
-      loop rest {
-        [] => raise UnmatchedParens("missing closing parenthesis")
-        [RParen, .. rest] => (List(subexps), rest)
-        _ as r => {
-          let (subexp, remaining) = parse_tokens(r)
-          subexps.push(subexp)
-          continue remaining
+      for view = rest {
+        match view {
+          [] => raise UnmatchedParens("missing closing parenthesis")
+          [RParen, .. rest] => break (List(subexps), rest)
+          _ as r => {
+            let (subexp, remaining) = parse_tokens(r)
+            subexps.push(subexp)
+            continue remaining
+          }
         }
       }
     }
@@ -104,26 +106,28 @@ fn Lexer::update_view_with_token(self : Lexer, view : StringView) -> String {
 ///|
 fn Lexer::decode(self : Lexer) -> Array[Token] raise {
   let tokens : Array[Token] = []
-  loop self.view() {
-    [] => ()
-    ['(', .. rest] => {
-      tokens.push(Lparen)
-      continue rest
-    }
-    [')', .. rest] => {
-      tokens.push(RParen)
-      continue rest
-    }
-    [' ' | '\n' | '\t', .. rest] => continue rest
-    ['"', ..] as view => {
-      self.update_view(view) // mark theh position, do the work
-      tokens.push(self.decode_string())
-      continue self.view()
-    }
-    _ as view => {
-      self.update_view(view)
-      tokens.push(self.decode_atom())
-      continue self.view()
+  for view = self.view() {
+    match view {
+      [] => break
+      ['(', .. rest] => {
+        tokens.push(Lparen)
+        continue rest
+      }
+      [')', .. rest] => {
+        tokens.push(RParen)
+        continue rest
+      }
+      [' ' | '\n' | '\t', .. rest] => continue rest
+      ['"', ..] as view => {
+        self.update_view(view) // mark theh position, do the work
+        tokens.push(self.decode_string())
+        continue self.view()
+      }
+      _ as view => {
+        self.update_view(view)
+        tokens.push(self.decode_atom())
+        continue self.view()
+      }
     }
   }
   tokens
@@ -136,11 +140,13 @@ fn Lexer::decode_string(self : Lexer) -> Token raise {
     ['"', .. next] => next
     _ => fail("expected \" in the beginning of string")
   }
-  let next = loop next {
-    ['"', .. next] => next
-    ['\n', ..] => fail("unexpected newline in string")
-    [_, .. rest] => continue rest
-    [] => fail("unexpected end of input")
+  let next = for view = next {
+    match view {
+      ['"', .. next] => break next
+      ['\n', ..] => fail("unexpected newline in string")
+      [_, .. rest] => continue rest
+      [] => fail("unexpected end of input")
+    }
   }
   Atom(self.update_view_with_token(next))
 }
@@ -149,16 +155,16 @@ fn Lexer::decode_string(self : Lexer) -> Token raise {
 test "decode_string" {
   fn decode_string(s) {
     Ok(Lexer::new(s).decode_string()) catch {
-      Failure(err) => Err(err.split("FAILED:")[1:].to_string()) // FIXME: upstream
+      @builtin.Failure(err) => Err(err.split("FAILED:")[1:].to_string()) // FIXME: upstream
       err => Err(err.to_string())
     }
   }
 
-  @json.inspect(decode_string("\"hello\""), content={ "Ok": "\"hello\"" })
-  @json.inspect(decode_string("\"hello\n\""), content={
+  json_inspect(decode_string("\"hello\""), content={ "Ok": "\"hello\"" })
+  json_inspect(decode_string("\"hello\n\""), content={
     "Err": "[\" unexpected newline in string\"]",
   })
-  @json.inspect(
+  json_inspect(
     decode_string(
       (
         #|"abc"
@@ -166,15 +172,17 @@ test "decode_string" {
     ),
     content={ "Ok": "\"abc\"" },
   )
-  @json.inspect(decode_string("\"d..\""), content={ "Ok": "\"d..\"" })
+  json_inspect(decode_string("\"d..\""), content={ "Ok": "\"d..\"" })
 }
 
 ///|
 /// TODO(upstream): fmt add `///|`
 fn Lexer::decode_atom(self : Lexer) -> Token {
-  let next = loop self.view() {
-    [] | ['(' | ')' | ' ' | '\n' | '\t', ..] as next => next
-    [_, .. rest] => continue rest
+  let next = for view = self.view() {
+    match view {
+      [] | ['(' | ')' | ' ' | '\n' | '\t', ..] as next => break next
+      [_, .. rest] => continue rest
+    }
   }
   Atom(self.update_view_with_token(next))
 }
@@ -183,19 +191,19 @@ fn Lexer::decode_atom(self : Lexer) -> Token {
 test "decode_atom" {
   // only toplevel can have labelled arguments  
   // fn aux(s,content~) raise{
-  //   @json.inspect(s, content~)
+  //   json_inspect(s, content~)
   // }  
   fn decode_atom(s) {
     Lexer::new(s).decode_atom()
     // catch {
-    //   Failure(err) => Err(err.split("FAILED:")[1:].to_string()) // FIXME: upstream
+    //   @builtin.Failure(err) => Err(err.split("FAILED:")[1:].to_string()) // FIXME: upstream
     //   err => Err(err.to_string())
     // }
   }
 
-  @json.inspect(decode_atom("hello "), content="hello")
-  @json.inspect(decode_atom("hell("), content="hell")
-  @json.inspect(decode_atom("hello+ "), content="hello+")
+  json_inspect(decode_atom("hello "), content="hello")
+  json_inspect(decode_atom("hell("), content="hell")
+  json_inspect(decode_atom("hello+ "), content="hello+")
 }
 
 ///|
@@ -246,18 +254,18 @@ test "decode_atom" {
 test "decode" {
   fn tokenize(s) {
     Ok(Lexer::new(s).decode()) catch {
-      Failure(err) => Err(err.split("FAILED:")[1:].to_string()) // FIXME: upstream
+      @builtin.Failure(err) => Err(err.split("FAILED:")[1:].to_string()) // FIXME: upstream
       err => Err(err.to_string())
     }
   }
 
-  @json.inspect(tokenize("(hello world)"), content={
+  json_inspect(tokenize("(hello world)"), content={
     "Ok": ["(", "hello", "world", ")"],
   })
-  @json.inspect(tokenize("(hello \"world\")"), content={
+  json_inspect(tokenize("(hello \"world\")"), content={
     "Ok": ["(", "hello", "\"world\"", ")"],
   })
-  @json.inspect(tokenize("(hello \"world\")"), content={
+  json_inspect(tokenize("(hello \"world\")"), content={
     "Ok": ["(", "hello", "\"world\"", ")"],
   })
 }
@@ -280,46 +288,46 @@ test "decode" {
 test {
   fn tokenize(s) {
     Ok(Lexer::new(s).decode()) catch {
-      Failure(err) => Err(err.split("FAILED:")[1:].to_string()) // FIXME: upstream
+      @builtin.Failure(err) => Err(err.split("FAILED:")[1:].to_string()) // FIXME: upstream
       err => Err(err.to_string())
     }
   }
 
   let tokens = tokenize("(begin (define x 10) (define y 5) (+ x y))")
   // let tokens = tokenize(v)
-  @json.inspect(tokens, content={
+  json_inspect(tokens, content={
     "Ok": [
       "(", "begin", "(", "define", "x", "10", ")", "(", "define", "y", "5", ")",
       "(", "+", "x", "y", ")", ")",
     ],
   })
   let tokens = tokenize("(if (> 5 2) 42 0)")
-  @json.inspect(tokens, content={
+  json_inspect(tokens, content={
     "Ok": ["(", "if", "(", ">", "5", "2", ")", "42", "0", ")"],
   })
   let tokens = tokenize("(= 5 5)")
-  @json.inspect(tokens, content={ "Ok": ["(", "=", "5", "5", ")"] })
+  json_inspect(tokens, content={ "Ok": ["(", "=", "5", "5", ")"] })
 }
 
 ///|
 test "tokenize" {
   let input = "(hello world)"
   let tokens = Lexer::new(input).decode()
-  @json.inspect(tokens, content=["(", "hello", "world", ")"])
+  json_inspect(tokens, content=["(", "hello", "world", ")"])
 }
 
 ///|
 test "tokenize unicode" {
   let input = "(你好 世界)"
   let tokens = Lexer::new(input).decode()
-  @json.inspect(tokens, content=["(", "你好", "世界", ")"])
+  json_inspect(tokens, content=["(", "你好", "世界", ")"])
 }
 
 ///|
 test "tokenize unicode emoji" {
   let input = "(👋🏻 世界)"
   let tokens = Lexer::new(input).decode()
-  @json.inspect(tokens, content=["(", "👋🏻", "世界", ")"])
+  json_inspect(tokens, content=["(", "👋🏻", "世界", ")"])
 }
 
 ///|
@@ -335,3 +343,13 @@ test "tokenize unicode emoji" {
 //     }
 //   }
 // }
+
+///|
+pub impl Show for Sexp with output(self, logger) {
+  logger.write_string(@debug.render(self.to_repr(), max_depth=2147483647))
+}
+
+///|
+pub impl Show for ParseError with output(self, logger) {
+  logger.write_string(@debug.render(self.to_repr(), max_depth=2147483647))
+}

--- a/sexp_test.mbt
+++ b/sexp_test.mbt
@@ -3,7 +3,7 @@
 ///|
 test "parse extra tokens" {
   let input = "(hello) world"
-  @json.inspect(try? @lisp_interpreter.parse_sexp(input), content={
+  json_inspect(try? @lisp_interpreter.parse_sexp(input), content={
     "Err": ["UnmatchedParens", "unexpected tokens at the end"],
   })
 }
@@ -11,7 +11,7 @@ test "parse extra tokens" {
 ///|
 test "parse unexpected closing paren" {
   let input = ")hello"
-  @json.inspect(try? @lisp_interpreter.parse_sexp(input), content={
+  json_inspect(try? @lisp_interpreter.parse_sexp(input), content={
     "Err": ["UnexpectedParens", "unexpected closing parenthesis"],
   })
 }
@@ -20,14 +20,14 @@ test "parse unexpected closing paren" {
 test "parse simple" {
   let input = "(hello world)"
   let result = @lisp_interpreter.parse_sexp(input)
-  @json.inspect(result, content=["List", [["Atom", "hello"], ["Atom", "world"]]])
+  json_inspect(result, content=["List", [["Atom", "hello"], ["Atom", "world"]]])
 }
 
 ///|
 test "parse nested" {
   let input = "(define (square x) (* x x))"
   let result = @lisp_interpreter.parse_sexp(input)
-  @json.inspect(result, content=[
+  json_inspect(result, content=[
     "List",
     [
       ["Atom", "define"],
@@ -51,7 +51,7 @@ test "parse error" {
 ///|
 test "parse empty" {
   let input = ""
-  @json.inspect(try? @lisp_interpreter.parse_sexp(input), content={
+  json_inspect(try? @lisp_interpreter.parse_sexp(input), content={
     "Err": "UnexpectedEOF",
   })
 }
@@ -60,7 +60,7 @@ test "parse empty" {
 test "parse parens" {
   let input = "(hello (world))"
   let result = @lisp_interpreter.parse_sexp(input)
-  @json.inspect(result, content=[
+  json_inspect(result, content=[
     "List",
     [["Atom", "hello"], ["List", [["Atom", "world"]]]],
   ])


### PR DESCRIPTION
Scoped nightly-compat work so `moon check --deny-warn` passes:
- 5 `derive(Show)` → `derive(Debug)` + manual Show
- 4 functional loops rewritten as `for view = X`
- `@json.inspect` → `json_inspect`
- `@strconv.parse_int` → `@string.parse_int`, `@array.View` → `ArrayView`
- `@builtin.Failure` pattern qualification
- Add missing core-package imports to moon.pkg

Pre-existing 3 test failures (let/let* unbound variable) persist on main — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/lisp_interpreter/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
